### PR TITLE
Added support for unicode languages in markdown

### DIFF
--- a/revelation/app.py
+++ b/revelation/app.py
@@ -78,7 +78,7 @@ class Revelation(object):
 
         :return: a list of strings with the slides content
         """
-        with open(path, "r") as presentation:
+        with open(path, "r", encoding="utf-8") as presentation:
             slides = presentation.read()
 
         return re.split("^{}$".format(separator), slides, flags=re.MULTILINE)
@@ -112,7 +112,7 @@ class Revelation(object):
         template = env.get_template("presentation.html")
 
         return Response(
-            template.render(**context), headers={"content-type": "text/html"}
+            template.render(**context), headers={"content-type": "text/html; charset=utf8"}
         )
 
     def wsgi_app(self, environ, start_response):

--- a/revelation/cli.py
+++ b/revelation/cli.py
@@ -207,7 +207,7 @@ def mkstatic(
 
     output_file = os.path.join(output_folder, output_file)
 
-    with open(output_file, "w") as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         f.write(app.dispatch_request(None).get_data(as_text=True))
 
     click.echo(


### PR DESCRIPTION
During my last training I've used unicode characters and I did the fix in the read/write files and in the webserver.